### PR TITLE
use total value up to current year instead of only inital value

### DIFF
--- a/ledger-afa.py
+++ b/ledger-afa.py
@@ -35,9 +35,12 @@ def get_afa_posts(journal, account, year):
 
     this way we can trace back inventory items which are being deprecated.
     """
-    top = journal.find_account(account)
-    accounts = [top] + get_sub_accounts(top)
+    top = journal.find_account_re(account)
 
+    if top is None:
+        return
+
+    accounts = [top] + get_sub_accounts(top)
     return [p for a in accounts for p in a.posts()
             if p.date.year == year]
 
@@ -182,6 +185,11 @@ def main():
 
     journal = ledger.read_journal(args.file)
     posts = get_afa_posts(journal, args.account, args.year)
+
+    if posts is None:
+        print("No such account: {}".format(args.account))
+        return
+
     inventory = [InventoryItem(i, args.year) for i in get_inventory(posts)]
     table = create_table(inventory, args.year)
 

--- a/ledger-afa.py
+++ b/ledger-afa.py
@@ -55,6 +55,7 @@ def get_inventory(posts):
 
     # monkey patch so we can use `Account` in `set`
     ledger.Account.__hash__ = lambda self: hash(self.fullname())
+    ledger.Account.__eq__ = lambda self, other: self.fullname() == other.fullname()
 
     inventory = set()
     for post in posts:

--- a/ledger-afa.py
+++ b/ledger-afa.py
@@ -151,12 +151,20 @@ class InventoryItem(object):
         self.initial_value = first_post.amount
 
         self.last_year_value = sum(p.amount for p in account.posts()
-                                   if p.date.year < year)
+                                   if p.date.year < year
+                                   # consider additional purchases in current year
+                                   or (p.date.year == year and p.amount > 0)
+                                   )
+
         self.next_year_value = sum(p.amount for p in account.posts()
                                    if p.date.year <= year)
+
         self.deprecation_amount = sum(p.amount for p in account.posts()
                                       if p.date.year == year
-                                      and p.id != first_post.id)
+                                      and p.id != first_post.id
+                                      # only consider deprecation
+                                      and p.amount < 0
+                                      )
 
 
 def main():

--- a/ledger-afa.py
+++ b/ledger-afa.py
@@ -70,7 +70,7 @@ def table_entry(
     date='',
     code='',
     item='',
-    initial_value='',
+    total_value='',
     last_year_value='',
     deprecation_amount='',
     next_year_value=''
@@ -79,7 +79,7 @@ def table_entry(
         date,
         colored(code, 'yellow'),
         item,
-        colored(str(initial_value), 'red'),
+        colored(str(total_value), 'red'),
         str(last_year_value),
         colored(str(deprecation_amount), 'cyan'),
         str(next_year_value),
@@ -107,7 +107,7 @@ def create_table(items, year):
 
     table = [map(color_header, header)]
 
-    sum_initial_value = sum(i.initial_value for i in items)
+    sum_total_value = sum(i.total_value for i in items)
     sum_last_year_value = sum(i.last_year_value for i in items)
     sum_deprecation_amount = sum(i.deprecation_amount for i in items)
     sum_next_year_value = sum(i.next_year_value for i in items)
@@ -117,7 +117,7 @@ def create_table(items, year):
             x.buy_date.isoformat(),
             x.code,
             x.item,
-            x.initial_value,
+            x.total_value,
             x.last_year_value,
             x.deprecation_amount,
             x.next_year_value,
@@ -126,7 +126,7 @@ def create_table(items, year):
 
     footer = table_entry(
         item='Gesamt',
-        initial_value=sum_initial_value,
+        total_value=sum_total_value,
         last_year_value=sum_last_year_value,
         deprecation_amount=sum_deprecation_amount,
         next_year_value=sum_next_year_value,
@@ -148,7 +148,9 @@ class InventoryItem(object):
         first_post = account.posts().next()
         self.code = first_post.xact.code
         self.buy_date = first_post.date
-        self.initial_value = first_post.amount
+        # instead of only taking initial value, accumulate all purchases
+        self.total_value = sum(p.amount for p in account.posts()
+                               if p.amount > 0 and p.date.year <= year)
 
         self.last_year_value = sum(p.amount for p in account.posts()
                                    if p.date.year < year


### PR DESCRIPTION
this is optional and actually opens up more questions.
- should we still use the initial purchase date if we had additional purchases or use the last one?
- with this change the initial value will change depending on which year is displayed, if there are additional purchases
- should there be more lines for an item if there are multiple purchases on that account? but that would make things more complicated

i'd like to have a sensible setting that doesn't confuse anyone by overwhelming with numbers, but delivers all the relevant information.
